### PR TITLE
Add query parameters for datetime, promotion_type, promotion_scope

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -331,6 +331,8 @@ class Promotion(db.Model):  # pylint: disable=too-many-instance-attributes
 
     @classmethod
     def to_list_deserializer(cls, deserializer):
+        """Converts a deserialization function to an equivalent one for a list of the specified object"""
+
         def deserialize_list(ls):
             return [deserializer(item) for item in ls]
 

--- a/service/models.py
+++ b/service/models.py
@@ -31,7 +31,7 @@ class PromotionType(enum.Enum):
     def deserialize(cls, promotion_type_str: str):
         """Convert promotion_type_str into a PromotionType or None"""
         try:
-            return PromotionType[promotion_type_str]
+            return PromotionType[promotion_type_str.upper()]
         except KeyError as error:
             raise DataValidationError(
                 f"Error: '{promotion_type_str}' is not a valid PromotionType"
@@ -49,7 +49,7 @@ class PromotionScope(enum.Enum):
     def deserialize(cls, promotion_scope_str: str):
         """Convert promotion_scope_str into a PromotionType or None"""
         try:
-            return PromotionScope[promotion_scope_str]
+            return PromotionScope[promotion_scope_str.upper()]
         except KeyError as error:
             raise DataValidationError(
                 f"Error: '{promotion_scope_str}' is not a valid PromotionType"

--- a/service/routes.py
+++ b/service/routes.py
@@ -98,9 +98,7 @@ def create_promotion():
     promotion.deserialize(data)
     promotion.create()
     message = promotion.serialize()
-    location_url = url_for(
-        "read", promotion_id=promotion.promotion_id, _external=True
-    )
+    location_url = url_for("read", promotion_id=promotion.promotion_id, _external=True)
     return jsonify(message), status.HTTP_201_CREATED, {"Location": location_url}
 
 
@@ -154,10 +152,11 @@ def delete(promotion_id):
 @app.route("/promotions", methods=["GET"])
 def read_all():
     """
-    Read details of specific promotion id
+    Read details of all promotions matching searach criteria
     """
     app.logger.info("Request to Retrieve all promotions")
-    promotions = Promotion.all()
+    filters = request.args
+    promotions = Promotion.find_with_filters(filters).all()
     return (
         jsonify([promotion.serialize() for promotion in promotions]),
         status.HTTP_200_OK,

--- a/service/routes.py
+++ b/service/routes.py
@@ -187,5 +187,11 @@ def abort_with_error(error_code, error_msg):
 
 
 def to_list_query(key, data):
+    """Converts a value in a dictionary to a list from a comma-separated string if it exists
+
+    Args:
+        key (str): the key to be converted
+        data (dict): the dict to convert it in
+    """
     if key in data:
         data[key] = str.split(data[key], ",")

--- a/service/routes.py
+++ b/service/routes.py
@@ -152,10 +152,17 @@ def delete(promotion_id):
 @app.route("/promotions", methods=["GET"])
 def read_all():
     """
-    Read details of all promotions matching searach criteria
+    Read details of all promotions matching search criteria
     """
-    app.logger.info("Request to Retrieve all promotions")
-    filters = request.args
+    app.logger.info("Request to Retrieve all promotions with filters: {filters}")
+    filters = request.args.to_dict(flat=True)
+    to_list_query("promotion_scope", filters)
+    to_list_query("promotion_type", filters)
+    datetime = filters.get("datetime")
+    promotion_scopes = filters.get("promotion_scope")
+    promotion_types = filters.get("promotion_types")
+    print(datetime, promotion_scopes, promotion_types)
+
     promotions = Promotion.find_with_filters(filters).all()
     return (
         jsonify([promotion.serialize() for promotion in promotions]),
@@ -177,3 +184,8 @@ def abort_with_error(error_code, error_msg):
     """
     app.logger.error(error_msg)
     abort(error_code, error_msg)
+
+
+def to_list_query(key, data):
+    if key in data:
+        data[key] = str.split(data[key], ",")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -366,6 +366,7 @@ class Promotions(TestCase):
         promotion4.start_date = datetime(2025, 1, 1)
         promotion4.end_date = datetime(2026, 1, 1)
         promotion4.promotion_scope = PromotionScope.PRODUCT_ID
+        promotion4.promotion_type = PromotionType.PERCENTAGE
         promotion4.create()
 
         test_filters = {
@@ -378,3 +379,9 @@ class Promotions(TestCase):
         self.assertEqual(len(results), 2)
         self.assertIn(promotion1.promotion_id, result_ids)
         self.assertIn(promotion4.promotion_id, result_ids)
+
+        test_filters2 = {"promotion_type": ["ABSOLUTE"]}
+        results2 = Promotion.find_with_filters(test_filters2).all()
+        result_ids2 = [result.promotion_id for result in results2]
+        self.assertEqual(len(results2), 3)
+        self.assertNotIn(promotion4.promotion_id, result_ids2)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -63,7 +63,9 @@ class TestYourResourceService(TestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         new_promotion = response.get_json()
         self.assertEqual(new_promotion["promotion_name"], promotion.promotion_name)
-        self.assertEqual(new_promotion["promotion_scope"], promotion.promotion_scope.name)
+        self.assertEqual(
+            new_promotion["promotion_scope"], promotion.promotion_scope.name
+        )
         self.assertEqual(new_promotion["promotion_type"], promotion.promotion_type.name)
         self.assertEqual(new_promotion["promotion_value"], promotion.promotion_value)
 
@@ -87,7 +89,7 @@ class TestYourResourceService(TestCase):
         """Test creating a Promotion for data validation error"""
         promotion = PromotionFactory()
         new_promotion = promotion.serialize()
-        new_promotion['modified_when'] = 'testInvalid'
+        new_promotion["modified_when"] = "testInvalid"
         response = self.client.post(
             "/promotions", json=new_promotion, content_type="application/json"
         )
@@ -109,10 +111,14 @@ class TestYourResourceService(TestCase):
             Promotion.create = mock_create_with_exception
 
             response = self.client.post(
-                "/promotions", json=promotion.serialize(), content_type="application/json"
+                "/promotions",
+                json=promotion.serialize(),
+                content_type="application/json",
             )
 
-            self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+            self.assertEqual(
+                response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
         finally:
             # Restore the original method
             Promotion.create = original_create
@@ -343,16 +349,16 @@ class TestYourResourceService(TestCase):
         promotion_1.create()
         promotion_2.create()
 
-        original_all = Promotion.all
+        original_find = Promotion.find_with_filters
         try:
 
             def mock_all():
                 raise ConnectionError
 
-            Promotion.all = mock_all
+            Promotion.find_with_filters = mock_all
             response = self.client.get("/promotions")
             self.assertEqual(
                 response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR
             )
         finally:
-            Promotion.all = original_all
+            Promotion.find_with_filters = original_find


### PR DESCRIPTION
Changed:
1. Added query parameters and parsing to read_all endpoint (GET /promotions)
2. Slight modifications to deserialization functions to allow non-capitalization
3. Utility functions 

Test and Coverage
![image](https://github.com/CSCI-GA-2820-SU24-001/promotions/assets/30424050/ce32680f-3648-4cc8-af79-4e42945d264c)
Lint Checks
![image](https://github.com/CSCI-GA-2820-SU24-001/promotions/assets/30424050/024acb33-cb41-4790-9839-5dec7ee976ce)
