### PR TITLE
Add activate endpoint and activate field in db with test cases

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -77,6 +77,7 @@ class Promotion(db.Model):  # pylint: disable=too-many-instance-attributes
     modified_by = db.Column(db.Uuid, nullable=True)
     created_when = db.Column(db.DateTime, nullable=False)
     modified_when = db.Column(db.DateTime, nullable=True)
+    active = db.Column(db.Boolean, nullable=False, default=False)
 
     def __repr__(self):
         return f"<Promotion {self.promotion_name} promotion_id=[{self.promotion_id}], promotion_name=[{self.promotion_name}]>"
@@ -136,6 +137,7 @@ class Promotion(db.Model):  # pylint: disable=too-many-instance-attributes
             "modified_when": (
                 datetime_to_str(self.modified_when) if self.modified_when else None
             ),
+            "active": self.active,
         }
 
     def deserialize(self, data):
@@ -193,6 +195,9 @@ class Promotion(db.Model):  # pylint: disable=too-many-instance-attributes
                 self.modified_when,
                 Promotion.deserialize_datetime,
             )
+            updated_promotion.active = Promotion.deserialize_with_default(
+                "active", data, self.active
+            )
             # Only update once all fields have been verified and deserialized
             self.promotion_id = updated_promotion.promotion_id
             self.promotion_name = updated_promotion.promotion_name
@@ -207,6 +212,7 @@ class Promotion(db.Model):  # pylint: disable=too-many-instance-attributes
             self.modified_by = updated_promotion.modified_by
             self.created_when = updated_promotion.created_when
             self.modified_when = updated_promotion.modified_when
+            self.active = updated_promotion.active
 
         except AttributeError as error:
             raise DataValidationError("Invalid attribute: " + error.args[0]) from error

--- a/service/routes.py
+++ b/service/routes.py
@@ -75,6 +75,12 @@ def index():
                         "modified_by": "ID of the user modifying the promotion",
                     },
                 },
+                "PUT /promotions/activate/{promotion_id}": {
+                    "description": "Activate a specific promotion",
+                    "params": {
+                        "promotion_id": "ID of the promotion to activate",
+                    },
+                },
             }
         ),
         status.HTTP_200_OK,
@@ -168,6 +174,20 @@ def read_all():
         jsonify([promotion.serialize() for promotion in promotions]),
         status.HTTP_200_OK,
     )
+
+
+@app.route("/promotions/activate/<int:promotion_id>", methods=["PUT"])
+def activate(promotion_id):
+    """Activates a Promotion with promotion_id"""
+    app.logger.info(f"Got request to activate Promotion with id: {promotion_id}")
+    promotion = Promotion.find(promotion_id)
+    if not promotion:
+        abort_with_error(
+            status.HTTP_404_NOT_FOUND, f"Promotion with id: {promotion_id} not found"
+        )
+    promotion.active = True
+    promotion.update()
+    return jsonify(promotion.serialize())
 
 
 ######################################################################

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -29,3 +29,4 @@ class PromotionFactory(factory.Factory):
     modified_by = uuid.uuid4()
     created_when = datetime.datetime(2024, 1, 1, 0, 0)
     modified_when = None
+    active = False

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -77,6 +77,7 @@ class Promotions(TestCase):
             test_promotion.created_when
         )
         assert serialized["modified_when"] is None
+        assert serialized["active"] == test_promotion.active
 
     def test_serialize_promotion_2(self):
         """It should deserialize a Promotion into a dict"""
@@ -96,6 +97,7 @@ class Promotions(TestCase):
             test_promotion.created_when
         )
         assert serialized["modified_when"] is None
+        assert serialized["active"] == test_promotion.active
 
     def test_serialized_promotion_with_missing_fields(self):
         """It should deserialize a Promotion into a dict with some fields as None"""
@@ -125,6 +127,7 @@ class Promotions(TestCase):
             "modified_by": default_uuid,
             "created_when": "2021-01-01",
             "modified_when": "2021-01-01",
+            "active": True,
         }
         promotion = Promotion()
         result = promotion.deserialize(promotion_json)
@@ -141,6 +144,7 @@ class Promotions(TestCase):
         assert result.modified_by == default_uuid
         assert result.created_when == datetime(2021, 1, 1, 0, 0)
         assert result.modified_when == datetime(2021, 1, 1, 0, 0)
+        assert result.active
 
     def test_deserialize_invalid_promotion(self):
         """It should throw an exception for any invalid formats"""

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -401,3 +401,23 @@ class TestYourResourceService(TestCase):
             )
         finally:
             Promotion.find_with_filters = original_find
+
+    def test_activate_with_invalid_promotion_id(self):
+        """It should not activate any promotions and return a 404 not found when an invalid_promotion_id is supplied"""
+        existing_promotion = PromotionFactory()
+        existing_promotion.create()
+        resp = self.client.put(f"/promotions/activate/{1234567}")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+        db.session.expire_all()
+        activated_promotion = Promotion.find(existing_promotion.promotion_id)
+        self.assertNotEqual(activated_promotion.active, True)
+
+    def test_activate_with_valid_promotion_id(self):
+        """It should switch the activate column of promotions with valid_promotion_id to True"""
+        existing_promotion = PromotionFactory()
+        existing_promotion.create()
+        resp = self.client.put(f"/promotions/activate/{existing_promotion.promotion_id}")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        db.session.expire_all()
+        activated_promotion = Promotion.find(existing_promotion.promotion_id)
+        assert activated_promotion.active


### PR DESCRIPTION
### Description:
Add activate endpoint and activate field in db with test cases

### Test result and coverage:
![image](https://github.com/CSCI-GA-2820-SU24-001/promotions/assets/132203093/dfd64de2-4d3c-4a9c-894f-b816e29adfab)
![image](https://github.com/CSCI-GA-2820-SU24-001/promotions/assets/132203093/4e3f0d17-57d0-461e-b734-d81a38d5c610)

### Lint check
![image](https://github.com/CSCI-GA-2820-SU24-001/promotions/assets/132203093/cb00a3b8-e71a-48f6-b18e-e8d9915df8f0)

### Story reference: 
https://app.zenhub.com/workspaces/promotions-su24-001-666234565dda150276ad19c5/issues/gh/csci-ga-2820-su24-001/promotions/9