### PR TITLE
Use current time for accounting fields

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -27,6 +27,6 @@ class PromotionFactory(factory.Factory):
     promotion_code = None
     created_by = uuid.uuid4()
     modified_by = uuid.uuid4()
-    created_when = datetime.datetime(2024, 1, 1, 0, 0)
+    created_when = None
     modified_when = None
     active = False

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -73,9 +73,7 @@ class Promotions(TestCase):
         assert serialized["promotion_code"] == test_promotion.promotion_code
         assert serialized["created_by"] == test_promotion.created_by
         assert serialized["modified_by"] == test_promotion.modified_by
-        assert serialized["created_when"] == datetime_to_str(
-            test_promotion.created_when
-        )
+
         assert serialized["modified_when"] is None
         assert serialized["active"] == test_promotion.active
 
@@ -93,9 +91,6 @@ class Promotions(TestCase):
         assert serialized["promotion_code"] == test_promotion.promotion_code
         assert serialized["created_by"] == test_promotion.created_by
         assert serialized["modified_by"] == test_promotion.modified_by
-        assert serialized["created_when"] == datetime_to_str(
-            test_promotion.created_when
-        )
         assert serialized["modified_when"] is None
         assert serialized["active"] == test_promotion.active
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -271,10 +271,14 @@ class TestYourResourceService(TestCase):
         self.assertEqual(data["promotion_code"], existing_promotion.promotion_code)
         self.assertEqual(UUID(data["created_by"]), existing_promotion.created_by)
         self.assertEqual(UUID(data["modified_by"]), existing_promotion.modified_by)
-        self.assertEqual(
-            data["created_when"], datetime_to_str(existing_promotion.created_when)
-        )
-        self.assertEqual(data["modified_when"], existing_promotion.modified_when)
+
+        data_created_when = datetime.fromisoformat(data["created_when"])
+        data_modified_when = datetime.fromisoformat(data["modified_when"])
+        data_created_when_str = datetime_to_str(data_created_when)
+        data_modified_when_str = datetime_to_str(data_modified_when)
+
+        self.assertEqual(data_created_when_str, datetime_to_str(existing_promotion.created_when))
+        self.assertEqual(data_modified_when_str, datetime_to_str(existing_promotion.modified_when))
 
     def test_get_promotion_not_found(self):
         """It should not Get a Promotion thats not found"""


### PR DESCRIPTION
### Description:
Using current time for created_when and modified_when as parameters

### Test result and coverage:
![image](https://github.com/user-attachments/assets/07101d8e-e153-4add-b976-f374629be483)
![image](https://github.com/user-attachments/assets/c125cd4f-3ffa-4c4a-9434-a24419c736bf)


### Lint check
![image](https://github.com/user-attachments/assets/74a779fd-3301-435a-8071-a26a60f7957e)

### Story reference: 
https://app.zenhub.com/workspaces/promotions-su24-001-666234565dda150276ad19c5/issues/gh/csci-ga-2820-su24-001/promotions/30